### PR TITLE
Add return value to update_profile

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -42,10 +42,12 @@ int main()
 
 int last_profile = -1;
 const char *last_match = "";
-void update_profile(const char *match)
+int update_profile(const char *match)
 {
+    int match_found = 0;
+
     if (strcmp(match, last_match) == 0)
-        return;
+        return match_found;
     else
         last_match = match;
 
@@ -57,7 +59,10 @@ void update_profile(const char *match)
     {
         struct Process process = process_list[i];
         if (strcmp(match, process.match) == 0)
+        {
             new_profile = process.profile;
+            match_found = 1;
+        }
     }
 
     if (last_profile != new_profile)
@@ -74,4 +79,5 @@ void update_profile(const char *match)
         wooting_usb_send_feature(WootDevResetAll, 0, 0, 0, 0);            // Reset (Load RGB)
         wooting_usb_send_feature(RefreshRgbColors, 0, 0, 0, new_profile); // Refresh RGB (Load Effect)
     }
+    return match_found;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -5,4 +5,4 @@
 #include <wooting-rgb-sdk.h>
 
 int main();
-void update_profile(const char *name);
+int update_profile(const char *name);

--- a/src/win_native.c
+++ b/src/win_native.c
@@ -52,7 +52,7 @@ void CALLBACK event_handler(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idO
         match_found = update_profile(title);
 
         if (match_found == 0)
-            match_found = update_profile(proc_title);
+            update_profile(proc_title);
     }
 
     free(title);

--- a/src/win_native.c
+++ b/src/win_native.c
@@ -50,12 +50,9 @@ void CALLBACK event_handler(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idO
         int match_found = 0;
 
         match_found = update_profile(title);
-        if (match_found == 1)
-            return;
-        
-        match_found = update_profile(proc_title);
-        if (match_found == 1)
-            return;
+
+        if (match_found == 0)
+            match_found = update_profile(proc_title);
     }
 
     free(title);

--- a/src/win_native.c
+++ b/src/win_native.c
@@ -16,7 +16,7 @@ void initialize_event_hook()
     );
 }
 
-void cleanup()
+void cleanup(void)
 {
     UnhookWinEvent(event_hook);
 }

--- a/src/win_native.c
+++ b/src/win_native.c
@@ -47,8 +47,15 @@ void CALLBACK event_handler(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idO
         strcpy((char*)old_title, (const char*)title);
         strcpy((char*)old_proc_title, (const char*)proc_title);
 
-        update_profile(title);
-        update_profile(proc_title);
+        int match_found = 0;
+
+        match_found = update_profile(title);
+        if (match_found == 1)
+            return;
+        
+        match_found = update_profile(proc_title);
+        if (match_found == 1)
+            return;
     }
 
     free(title);

--- a/src/win_native.c
+++ b/src/win_native.c
@@ -42,10 +42,10 @@ void CALLBACK event_handler(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idO
     printf("%s, %d, %s, %d\n", title, tid, proc_title, pid);
 #endif
 
-    if (strcmp(old_title, title) || strcmp(old_proc_title, proc_title))
+    if (strcmp((const char*)old_title, (const char*)title) || strcmp((const char*)old_proc_title, (const char*)proc_title))
     {
-        strcpy(old_title, title);
-        strcpy(old_proc_title, proc_title);
+        strcpy((char*)old_title, (const char*)title);
+        strcpy((char*)old_proc_title, (const char*)proc_title);
 
         update_profile(title);
         update_profile(proc_title);

--- a/src/win_native.h
+++ b/src/win_native.h
@@ -3,6 +3,7 @@
 #include <winuser.h>
 #include <psapi.h>
 
+void cleanup(void);
 void start_listening();
 void CALLBACK event_handler(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idObject, LONG idChild,
                             DWORD dwEventThread, DWORD dwmsEventTime);


### PR DESCRIPTION
This PR adds a return value to `update_profile` so another function using it can check if there was a match found or not.

Also includes some smaller fixes in the windows code to prevent compiler warnings.